### PR TITLE
feat: add test environment and origin query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The following parameters are configurable for the API Client:
 | Parameter | Type | Description |
 |  --- | --- | --- |
 | userAgent | `string` |  |
+| customUrl | `string` | The testing domain for the API<br>*Default*: `'https://localhost:44301/api'` |
+| environment | `Environment` | The API environment. <br> **Default: `Environment.Production`** |
 | timeout | `number` | Timeout for API calls.<br>*Default*: `30000` |
 | httpClientOptions | [`Partial<HttpClientOptions>`](doc/http-client-options.md) | Stable configurable http client options. |
 | unstableHttpClientOptions | `any` | Unstable configurable http client options. |
@@ -87,7 +89,7 @@ The following parameters are configurable for the API Client:
 The API client can be initialized as follows:
 
 ```ts
-import { Client, LogLevel } from 'apimatic-apilib';
+import { Client, Environment, LogLevel } from 'apimatic-apilib';
 
 const client = new Client({
   customHeaderAuthenticationCredentials: {
@@ -95,6 +97,7 @@ const client = new Client({
   },
   userAgent: 'user-agent',
   timeout: 30000,
+  environment: Environment.Production,
   logging: {
     logLevel: LogLevel.Info,
     logRequest: {
@@ -104,8 +107,20 @@ const client = new Client({
       logHeaders: true
     }
   },
+  customUrl: 'https://localhost:44301/api',
 });
 ```
+
+## Environments
+
+The SDK can be configured to use a different environment for making API calls. Available environments are:
+
+### Fields
+
+| Name | Description |
+|  --- | --- |
+| production | **Default** |
+| testing | - |
 
 ## Authorization
 

--- a/doc/client.md
+++ b/doc/client.md
@@ -39,20 +39,3 @@ const client = new Client({
 });
 ```
 
-## Apimatic API Client
-
-The gateway for the SDK. This class acts as a factory for the Controllers and also holds the configuration of the SDK.
-
-## Controllers
-
-| Name | Description |
-|  --- | --- |
-| apisManagement | Gets ApisManagementController |
-| codeGenerationImportedApis | Gets CodeGenerationImportedApisController |
-| codeGenerationExternalApis | Gets CodeGenerationExternalApisController |
-| transformation | Gets TransformationController |
-| docsPortalManagement | Gets DocsPortalManagementController |
-| apiValidationImportedApis | Gets ApiValidationImportedApisController |
-| apiValidationExternalApis | Gets ApiValidationExternalApisController |
-| docsPortalGenerationAsync | Gets DocsPortalGenerationAsyncController |
-

--- a/doc/client.md
+++ b/doc/client.md
@@ -6,6 +6,8 @@ The following parameters are configurable for the API Client:
 | Parameter | Type | Description |
 |  --- | --- | --- |
 | userAgent | `string` |  |
+| customUrl | `string` | The testing domain for the API<br>*Default*: `'https://localhost:44301/api'` |
+| environment | `Environment` | The API environment. <br> **Default: `Environment.Production`** |
 | timeout | `number` | Timeout for API calls.<br>*Default*: `30000` |
 | httpClientOptions | [`Partial<HttpClientOptions>`](../doc/http-client-options.md) | Stable configurable http client options. |
 | unstableHttpClientOptions | `any` | Unstable configurable http client options. |
@@ -15,7 +17,7 @@ The following parameters are configurable for the API Client:
 The API client can be initialized as follows:
 
 ```ts
-import { Client, LogLevel } from 'apimatic-apilib';
+import { Client, Environment, LogLevel } from 'apimatic-apilib';
 
 const client = new Client({
   customHeaderAuthenticationCredentials: {
@@ -23,6 +25,7 @@ const client = new Client({
   },
   userAgent: 'user-agent',
   timeout: 30000,
+  environment: Environment.Production,
   logging: {
     logLevel: LogLevel.Info,
     logRequest: {
@@ -32,6 +35,7 @@ const client = new Client({
       logHeaders: true
     }
   },
+  customUrl: 'https://localhost:44301/api',
 });
 ```
 

--- a/doc/controllers/code-generation-external-apis.md
+++ b/doc/controllers/code-generation-external-apis.md
@@ -32,6 +32,7 @@ async generateSdkViaFile(
   accept: Accept,
   file: FileWrapper,
   template: Platforms,
+  queryParameters?: Record<string, string>,
   requestOptions?: RequestOptions
 ): Promise<ApiResponse<UserCodeGeneration>>
 ```
@@ -43,6 +44,7 @@ async generateSdkViaFile(
 | `accept` | [`Accept`](../../doc/models/accept.md) | Header, Required | Must be set to 'application/json' to ensure JSON response format |
 | `file` | `FileWrapper` | Form, Required | The API specification file.<br>The type of the specification file should be any of the [supported formats](https://docs.apimatic.io/api-transformer/overview-transformer#supported-input-formats). |
 | `template` | [`Platforms`](../../doc/models/platforms.md) | Form, Required | The structure contains platforms that APIMatic CodeGen can generate SDKs and Docs in. |
+| `queryParameters` | `Record<string, string>` | Optional | Pass additional query parameters. |
 | `requestOptions` | `RequestOptions \| undefined` | Optional | Pass additional request options. |
 
 ## Response Type
@@ -58,11 +60,16 @@ const file = new FileWrapper(fs.createReadStream('dummy_file'));
 
 const template = Platforms.CsNetStandardLib;
 
+const queryParameters: Record<string, string> = {
+  'key0': 'additionalQueryParams2'
+};
+
 try {
   const { result, ...httpResponse } = await codeGenerationExternalApisController.generateSdkViaFile(
     accept,
     file,
-    template
+    template,
+    queryParameters
   );
   // Get more response info...
   // const { statusCode, headers } = httpResponse;

--- a/doc/controllers/docs-portal-management.md
+++ b/doc/controllers/docs-portal-management.md
@@ -186,6 +186,7 @@ The endpoint returns a zip file that contains a static Site and can be hosted on
 async generateOnPremPortalViaBuildInput(
   contentType: ContentType,
   file: FileWrapper,
+  queryParameters?: Record<string, string>,
   requestOptions?: RequestOptions
 ): Promise<ApiResponse<NodeJS.ReadableStream | Blob>>
 ```
@@ -196,6 +197,7 @@ async generateOnPremPortalViaBuildInput(
 |  --- | --- | --- | --- |
 | `contentType` | [`ContentType`](../../doc/models/content-type.md) | Header, Required | - |
 | `file` | `FileWrapper` | Form, Required | The input file to the Portal Generator. Must contain the build file. |
+| `queryParameters` | `Record<string, string>` | Optional | Pass additional query parameters. |
 | `requestOptions` | `RequestOptions \| undefined` | Optional | Pass additional request options. |
 
 ## Response Type
@@ -209,10 +211,15 @@ const contentType = ContentType.EnumMultipartformdata;
 
 const file = new FileWrapper(fs.createReadStream('dummy_file'));
 
+const queryParameters: Record<string, string> = {
+  'key0': 'additionalQueryParams2'
+};
+
 try {
   const { result, ...httpResponse } = await docsPortalManagementController.generateOnPremPortalViaBuildInput(
     contentType,
-    file
+    file,
+    queryParameters
   );
   // Get more response info...
   // const { statusCode, headers } = httpResponse;

--- a/doc/controllers/transformation.md
+++ b/doc/controllers/transformation.md
@@ -30,6 +30,7 @@ async transformViaFile(
   contentType: ContentType,
   file: FileWrapper,
   exportFormat: ExportFormats,
+  queryParameters?: Record<string, string>,
   requestOptions?: RequestOptions
 ): Promise<ApiResponse<Transformation>>
 ```
@@ -41,6 +42,7 @@ async transformViaFile(
 | `contentType` | [`ContentType`](../../doc/models/content-type.md) | Header, Required | - |
 | `file` | `FileWrapper` | Form, Required | The API specification file.<br>The type of the specification file should be any of the [supported formats](https://docs.apimatic.io/api-transformer/overview-transformer#supported-input-formats). |
 | `exportFormat` | [`ExportFormats`](../../doc/models/export-formats.md) | Form, Required | The structure contains API specification formats that Transformer can convert to. |
+| `queryParameters` | `Record<string, string>` | Optional | Pass additional query parameters. |
 | `requestOptions` | `RequestOptions \| undefined` | Optional | Pass additional request options. |
 
 ## Response Type
@@ -56,11 +58,16 @@ const file = new FileWrapper(fs.createReadStream('dummy_file'));
 
 const exportFormat = ExportFormats.Wsdl;
 
+const queryParameters: Record<string, string> = {
+  'key0': 'additionalQueryParams2'
+};
+
 try {
   const { result, ...httpResponse } = await transformationController.transformViaFile(
     contentType,
     file,
-    exportFormat
+    exportFormat,
+    queryParameters
   );
   // Get more response info...
   // const { statusCode, headers } = httpResponse;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,11 @@
 {
-  "version": "3.0.0",
+  "name": "@apimatic/sdk",
+  "description": "This API gives you programmatic access to APIMatic's Code Generation, Transformers Engine and Docs Generation.",
+  "author": {
+    "name": "Team APIMatic",
+    "email": "contactus@apimatic.io"
+  },
+  "version": "0.2.0-alpha.3",
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",
@@ -12,25 +18,26 @@
   "engines": {
     "node": ">=14.17.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "apimatic",
+    "sdk",
+    "api"
+  ],
   "scripts": {
     "build": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
     "prepare": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
     "lint": "eslint **/*.ts --ignore-path .eslintignore",
     "lint:fix": "eslint **/*.ts --ignore-path .eslintignore --fix"
   },
-  "peerDependencies": {},
   "prettier": {
     "printWidth": 80,
     "semi": true,
     "singleQuote": true,
     "trailingComma": "es5",
     "quoteProps": "preserve"
-  },
-  "name": "apimatic-apilib",
-  "description": "This API gives you programmatic access to APIMatic's Code Generation, Docs Generation and Transformation Engine",
-  "author": {
-    "name": "Team APIMatic",
-    "email": "contactus@apimatic.io"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,5 @@
 {
-  "name": "@apimatic/sdk",
-  "description": "This API gives you programmatic access to APIMatic's Code Generation, Transformers Engine and Docs Generation.",
-  "author": {
-    "name": "Team APIMatic",
-    "email": "contactus@apimatic.io"
-  },
-  "version": "0.2.0-alpha.3",
+  "version": "3.0.0",
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",
@@ -18,26 +12,25 @@
   "engines": {
     "node": ">=14.17.0"
   },
-  "publishConfig": {
-    "access": "public"
-  },
-  "keywords": [
-    "apimatic",
-    "sdk",
-    "api"
-  ],
   "scripts": {
     "build": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
     "prepare": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
     "lint": "eslint **/*.ts --ignore-path .eslintignore",
     "lint:fix": "eslint **/*.ts --ignore-path .eslintignore --fix"
   },
+  "peerDependencies": {},
   "prettier": {
     "printWidth": 80,
     "semi": true,
     "singleQuote": true,
     "trailingComma": "es5",
     "quoteProps": "preserve"
+  },
+  "name": "apimatic-apilib",
+  "description": "This API gives you programmatic access to APIMatic's Code Generation, Docs Generation and Transformation Engine",
+  "author": {
+    "name": "Team APIMatic",
+    "email": "contactus@apimatic.io"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "Team APIMatic",
     "email": "contactus@apimatic.io"
   },
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.4",
   "license": "MIT",
   "sideEffects": false,
   "main": "dist/cjs/index.js",
@@ -48,7 +48,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "29.2.6",
     "tslib": "^2.5.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.2.0"
   },
   "dependencies": {
     "@apimatic/authentication-adapters": "^0.5.10",

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,6 +20,7 @@ import {
 } from './defaultConfiguration';
 import { ApiLogger, LoggingOptions, mergeLoggingOptions } from './core';
 import { ApiError } from './core';
+import { pathTemplate, SkipEncode } from './core';
 import { setHeader } from './core';
 import {
   AbortError,
@@ -98,6 +99,11 @@ function getBaseUri(server: Server = 'default', config: Configuration): string {
   if (config.environment === Environment.Production) {
     if (server === 'default') {
       return 'https://api.apimatic.io';
+    }
+  }
+  if (config.environment === Environment.Testing) {
+    if (server === 'default') {
+      return pathTemplate`${new SkipEncode(config.customUrl)}`;
     }
   }
   throw new Error('Could not get Base URL. Invalid environment or server.');

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -12,6 +12,7 @@ export interface Configuration {
   timeout: number;
   userAgent: string;
   environment: Environment;
+  customUrl: string;
   customHeaderAuthenticationCredentials?: {
     'Authorization': string;
   };
@@ -23,4 +24,5 @@ export interface Configuration {
 /** Environments available for API */
 export enum Environment {
   Production = 'production',
+  Testing = 'testing',
 }

--- a/src/controllers/codeGenerationExternalApisController.ts
+++ b/src/controllers/codeGenerationExternalApisController.ts
@@ -42,6 +42,7 @@ export class CodeGenerationExternalApisController extends BaseController {
     accept: Accept,
     file: FileWrapper,
     template: Platforms,
+    queryParameters?: Record<string, string>,
     requestOptions?: RequestOptions
   ): Promise<ApiResponse<UserCodeGeneration>> {
     const req = this.createRequest(
@@ -53,6 +54,7 @@ export class CodeGenerationExternalApisController extends BaseController {
       template: [template, platformsSchema],
     });
     req.header('Accept', mapped.accept);
+    req.query(queryParameters);
     req.formData({ file: file, template: mapped.template });
     req.throwOn(400, BadRequestResponseSdkError, 'Bad Request');
     req.throwOn(401, UnauthorizedResponseError, 'Unauthorized');

--- a/src/controllers/docsPortalManagementController.ts
+++ b/src/controllers/docsPortalManagementController.ts
@@ -124,6 +124,7 @@ export class DocsPortalManagementController extends BaseController {
   async generateOnPremPortalViaBuildInput(
     contentType: ContentType,
     file: FileWrapper,
+    queryParameters?: Record<string, string>,
     requestOptions?: RequestOptions
   ): Promise<ApiResponse<NodeJS.ReadableStream | Blob>> {
     const req = this.createRequest('POST', '/portal');
@@ -131,6 +132,7 @@ export class DocsPortalManagementController extends BaseController {
       contentType: [contentType, contentTypeSchema],
     });
     req.header('Content-Type', mapped.contentType);
+    req.query(queryParameters);
     req.formData({ file: file });
     req.throwOn(400, ProblemDetailsError, 'Bad Request');
     req.throwOn(401, UnauthorizedResponseError, 'Unauthorized');

--- a/src/controllers/transformationController.ts
+++ b/src/controllers/transformationController.ts
@@ -35,6 +35,7 @@ export class TransformationController extends BaseController {
     contentType: ContentType,
     file: FileWrapper,
     exportFormat: ExportFormats,
+    queryParameters?: Record<string, string>,
     requestOptions?: RequestOptions
   ): Promise<ApiResponse<Transformation>> {
     const req = this.createRequest(
@@ -46,6 +47,7 @@ export class TransformationController extends BaseController {
       exportFormat: [exportFormat, exportFormatsSchema],
     });
     req.header('Content-Type', mapped.contentType);
+    req.query(queryParameters);
     req.formData({ file: file, export_format: mapped.exportFormat });
     req.authenticate([{ authorization: true }]);
     return req.callAsJson(transformationSchema, requestOptions);

--- a/src/defaultConfiguration.ts
+++ b/src/defaultConfiguration.ts
@@ -27,8 +27,8 @@ export const DEFAULT_RETRY_CONFIG: RetryConfiguration = {
   retryInterval: 1,
   maximumRetryWaitTime: 0,
   backoffFactor: 2,
-  httpStatusCodesToRetry: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524, 408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
-  httpMethodsToRetry: ['GET', 'PUT', 'GET', 'PUT'],
+  httpStatusCodesToRetry: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
+  httpMethodsToRetry: ['GET', 'PUT'],
 };
 
 /** Default values for logging options. */

--- a/src/defaultConfiguration.ts
+++ b/src/defaultConfiguration.ts
@@ -17,6 +17,7 @@ export const DEFAULT_CONFIGURATION: Configuration = {
   timeout: 30000,
   userAgent: '',
   environment: Environment.Production,
+  customUrl: 'https://localhost:44301/api',
 };
 
 /** Default values for retry configuration parameters. */
@@ -26,8 +27,8 @@ export const DEFAULT_RETRY_CONFIG: RetryConfiguration = {
   retryInterval: 1,
   maximumRetryWaitTime: 0,
   backoffFactor: 2,
-  httpStatusCodesToRetry: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
-  httpMethodsToRetry: ['GET', 'PUT'],
+  httpStatusCodesToRetry: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524, 408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
+  httpMethodsToRetry: ['GET', 'PUT', 'GET', 'PUT'],
 };
 
 /** Default values for logging options. */


### PR DESCRIPTION
- Adds test environment for testing.
- Adds query parameter called `origin` to transform, portal generation and sdk generation endpoints.